### PR TITLE
⚡️ Implement prefetching for product detail data

### DIFF
--- a/src/components/Common/NavBar.tsx
+++ b/src/components/Common/NavBar.tsx
@@ -24,9 +24,9 @@ const NavBar = () => {
 
   // 현재 유저의 전체 장바구니 데이터 가져오기
   const { data: cartDatas } = useQuery(
-    ["allcartproduct"],
+    ["allcartproduct", user?.userId],
     () => fetchCart(query(collection(db, "cart"), where("userId", "==", user?.userId)), null),
-    { enabled: !!user }
+    { enabled: !!user?.userId }
   );
 
   return (

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -7,6 +7,9 @@ import { useAuth } from "@/AuthContext";
 import { useState } from "react";
 import LazyImage from "../Common/LazyImage";
 import { MoreHorizontal } from "lucide-react";
+import { db } from "@/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { useQueryClient } from "react-query";
 
 interface ProductCardProps {
   product: Product;
@@ -19,6 +22,22 @@ export const ProductCard = ({ product }: ProductCardProps) => {
 
   const [isHovered, setIsHovered] = useState(false);
 
+  const queryClient = useQueryClient();
+
+  const fetchProduct = async (pid: string) => {
+    if (pid) {
+      const docRef = doc(db, "products", pid);
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return docSnap.data() as Product;
+      }
+    }
+  };
+
+  const prefetchProductData = () => {
+    queryClient.prefetchQuery(["productDetail", product.id], () => fetchProduct(product.id));
+  };
+
   return (
     <Card
       className="w-56 flex flex-col p-5 h-fit gap-2 mr-4 cursor-pointer"
@@ -30,6 +49,7 @@ export const ProductCard = ({ product }: ProductCardProps) => {
             : `/productdetail/${product.id}`
         );
       }}
+      onMouseOver={prefetchProductData}
     >
       <div
         className="flex items-center justify-center bg-gray-100 h-44 w-44 relative"


### PR DESCRIPTION
## ⚡️ Description

상품 상세 조회에 데이터 prefetching을 적용하여 상세 페이지 데이터를 미리 받아오고, 첫 화면 렌더링 속도를 개선하는 과정

## 🔍 주요 변경 사항

- 상품 상세 페이지 데이터 fetch useQuery 적용
- 상품 카드 마우스 오버 시 상세 데이터 prefetching

## 💡 관련 이슈

Resolve #49 
